### PR TITLE
fixed ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       # ------------------------------------------------------
       - name: Install dependencies
         # --no-interaction prevents prompts in CI
-        run: poetry install --no-interaction
+        run: poetry install --no-interaction --no-root
 
 
       # ------------------------------------------------------


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust CI dependency installation to use 'poetry install --no-interaction --no-root' to skip installing the current package.